### PR TITLE
using icu tokenizer in sqlite3 full text search

### DIFF
--- a/sources/master/search.sql
+++ b/sources/master/search.sql
@@ -18,6 +18,7 @@ ATTACH DATABASE '__DIR__/db/taginfo-db.db' AS db;
 
 DROP TABLE IF EXISTS ftsearch;
 CREATE VIRTUAL TABLE ftsearch USING fts3 (
+    tokenize=__TOKENIZER__,
     key       TEXT,
     value     TEXT,
     count_all INTEGER

--- a/sources/master/update.sh
+++ b/sources/master/update.sh
@@ -25,8 +25,9 @@ SELECTION_DB=$DIR/selection.db
 
 echo "`$DATECMD` Create search database..."
 
+tokenizer=`../../bin/taginfo-config.rb sources.master.tokenizer simple`
 rm -f $DIR/taginfo-search.db
-$M4 --prefix-builtins -D __DIR__=$DIR search.sql | sqlite3 $DIR/taginfo-search.db
+$M4 --prefix-builtins -D __DIR__=$DIR -D __TOKENIZER__=$tokenizer search.sql | sqlite3 $DIR/taginfo-search.db
 
 echo "`$DATECMD` Create master database..."
 

--- a/taginfo-config-example.json
+++ b/taginfo-config-example.json
@@ -95,7 +95,13 @@
             // Minimum number of relations per type to make this
             // relation type "interesting", ie. to make it show
             // up as a relation type.
-            "min_count_relations_per_type": 100
+            "min_count_relations_per_type": 100,
+	    // Tokenizer for sqlite full-text search. Complex or custom
+	    // tokenizers, e.g., icu and unicode61, may be more suitable for
+	    // some locales. You may need newer sqlite3 or to recompile
+	    // sqlite3 to use those tokenizers.
+	    // See http://www.sqlite.org/fts3.html#tokenizer for detail.
+	    "tokenizer": "simple"
         }
     },
     "logging": {


### PR DESCRIPTION
OpenStreetMap is an international project, so icu tokenizer is more appropriate than the default "simple" tokenizer.

icu tokenizer is very helpful for Chinese text search. For example, we can find "中山高速公路"(Jhongshan Freeway) in taginfo but not "高速公路" (freeway). This is because the "simple" tokenizer doesn't understand word boundaries of Chinese and doesn't know "高速公路" is a word as well. With icu tokenizer, we can search Chinese tags using substring. I guess it is helpful for other languages, too.

I have tested icu tokenizer with Taiwan extract and it works well. I don't have idea about the performance impact on large scale database, the main taginfo site. You may need to test it before apply.

p.s. you may need to recompile sqlite3 with "icu" support if it is not enabled yet.