### PR TITLE
Add support for optional extra reports in historic_development report

### DIFF
--- a/taginfo-config-example.json
+++ b/taginfo-config-example.json
@@ -108,6 +108,17 @@
     },
     // Settings for the web user interface
     "user_interface": {
+        // Optional extra reports from history_stats table
+        "historic_development": {
+            "objects": {
+                "tab_name": "Objects",
+                "tab_title": "Object count"
+            },
+            "projects": {
+                "tab_name": "Projects",
+                "tab_title": "Project count"
+            }
+        },
         "key_page": {
             "show_tab_similar": false
         }

--- a/web/views/reports/historic_development.erb
+++ b/web/views/reports/historic_development.erb
@@ -7,6 +7,11 @@
         <li><a href="#num_keys"><%= h(t.osm.keys) %></a></li>
         <li><a href="#num_tags"><%= h(t.osm.tags) %></a></li>
         <li><a href="#relation_types"><%= h(t.osm.relation_types) %></a></li>
+<% if reports = TaginfoConfig.get('user_interface.historic_development', false) %>
+  <% reports.keys.each do |report| %>
+        <li><a href="#<%= report %>"><%= h(reports[report]["tab_name"]) %></a></li>
+  <% end %>
+<% end %>
     </ul>
     <div id="num_keys">
         <h2><%= h(t.reports.historic_development.keys.title) %></h2>
@@ -20,5 +25,13 @@
         <h2><%= h(t.reports.historic_development.relation_types.title) %></h2>
         <div class="canvas" id="canvas_relation_types"></div>
     </div>
+<% if reports = TaginfoConfig.get('user_interface.historic_development', false) %>
+  <% reports.keys.each do |report| %>
+    <div id="<%= report %>">
+        <h2><%= h(reports[report]["tab_title"]) %></h2>
+        <div class="canvas" id="canvas_<%= report %>"></div>
+    </div>
+  <% end %>
+<% end %>
 </div>
 <% javascript_for(:d3) %>

--- a/web/viewsjs/reports/historic_development.js.erb
+++ b/web/viewsjs/reports/historic_development.js.erb
@@ -1,8 +1,13 @@
 <%
 page = @trans.t.reports.historic_development
-
+history_stats = ['num_keys', 'num_tags', 'relation_types']
+if reports = TaginfoConfig.get('user_interface.historic_development', false)
+    reports.keys.each do |report|
+        history_stats.push(report)
+    end
+end
 data = {}
-['num_keys', 'num_tags', 'relation_types'].each do |key|
+history_stats.each do |key|
     data[key] = @db.execute("SELECT udate, value FROM history.history_stats WHERE key=? ORDER BY udate", key).map do |row|
         [ row['udate'], row['value'].to_i ]
     end


### PR DESCRIPTION
Add support for optional extra reports in historic_development report  defined in taginfo-config.json

To be honest this is probably not the best approach as it has translation support issues.

Maybe a better long term approach is to add translations for all entries of history_stats.key and offer a dropdown to select any key in history_stats table.

This is currently live in http://taginfo.openstreetmap.ie/reports/historic_development
