### PR TITLE
Improve layout on varied screen sizes

### DIFF
--- a/web/public/css/taginfo.css
+++ b/web/public/css/taginfo.css
@@ -108,7 +108,9 @@ a.section {
     text-decoration: none;
 }
 
-div.pre {
+div#pre-text {
+    float: left;
+    max-width: 60em;
     margin-bottom: 20px;
 }
 

--- a/web/public/css/taginfo.css
+++ b/web/public/css/taginfo.css
@@ -232,6 +232,7 @@ input:focus {
 
 div#main {
     margin: 0 20px;
+    clear: both;
 }
 
 /* ========== */
@@ -309,6 +310,10 @@ table.boxes td.box table {
 }
 
 /* ==========  */
+
+div#tabs {
+    clear: both;
+}
 
 div#tabs h2, div.box h2 {
     margin: 0 0 10px 0;

--- a/web/public/css/taginfo.css
+++ b/web/public/css/taginfo.css
@@ -241,11 +241,9 @@ div#main {
 
 div#footer {
     clear: both;
-    position: relative;
     font-size: 90%;
     margin: 0 20px;
     padding: 4px 0;
-    height: 20px;
 }
 
 div#footer_left {
@@ -739,4 +737,3 @@ table.wiki-images td.images div img {
     max-height: 50px;
     top: 0;
 }
-

--- a/web/public/css/taginfo.css
+++ b/web/public/css/taginfo.css
@@ -178,18 +178,12 @@ div#header {
 }
 
 div#header_date {
-    position: absolute;
-    top: 12px;
-    right: 20px;
     font-size: 80%;
     text-align: right;
     color: #808080;
 }
 
 div#header div#header_forms {
-    position: absolute;
-    right: 20px;
-    top: 31px;
 }
 
 div#header div#header_forms form {

--- a/web/public/css/taginfo.css
+++ b/web/public/css/taginfo.css
@@ -182,9 +182,10 @@ div#header_logo {
     float: left;
 }
 
-div#header_date {
+div#footer_date {
     display: inline-block;
     float: right;
+    clear: right;
     font-size: 80%;
     text-align: right;
     color: #808080;

--- a/web/public/css/taginfo.css
+++ b/web/public/css/taginfo.css
@@ -330,7 +330,7 @@ div#tabs form {
 /* ========== */
 
 div#tools {
-    clear: both;
+    clear: right;
     float: right;
     font-size: 80%;
     margin-top: 4px;
@@ -376,7 +376,6 @@ select#list {
 
 form#filter-form {
     margin-top: 0px;
-    clear: both;
     float: right;
 }
 

--- a/web/public/css/taginfo.css
+++ b/web/public/css/taginfo.css
@@ -184,10 +184,9 @@ div#header_logo {
     float: left;
 }
 
-div#footer_date {
+div#header_date {
     display: inline-block;
     float: right;
-    clear: right;
     font-size: 80%;
     text-align: right;
     color: #808080;

--- a/web/public/css/taginfo.css
+++ b/web/public/css/taginfo.css
@@ -245,12 +245,11 @@ div#footer {
 }
 
 div#footer_left {
-    position: absolute;
+    float: left;
 }
 
 div#footer_right {
-    position: absolute;
-    right: 0px;
+    float: right;
     text-align: right;
 }
 

--- a/web/public/css/taginfo.css
+++ b/web/public/css/taginfo.css
@@ -177,13 +177,22 @@ div#header {
     padding: 15px 20px 20px 20px;
 }
 
+div#header_logo {
+    display: inline-block;
+    float: left;
+}
+
 div#header_date {
+    display: inline-block;
+    float: right;
     font-size: 80%;
     text-align: right;
     color: #808080;
 }
 
 div#header div#header_forms {
+    float: right;
+    clear: right;
 }
 
 div#header div#header_forms form {

--- a/web/public/js/taginfo.js
+++ b/web/public/js/taginfo.js
@@ -26,6 +26,10 @@ function resize_box() {
     height -= jQuery('.ui-tabs-nav').outerHeight(true);
     height -= jQuery('div#footer').outerHeight(true);
 
+    if (height < 440) {
+        height = 440;
+    }
+
     wrapper.outerHeight(height);
 }
 

--- a/web/public/js/taginfo.js
+++ b/web/public/js/taginfo.js
@@ -25,6 +25,7 @@ function resize_box() {
     height -= jQuery('div.pre').outerHeight(true);
     height -= jQuery('.ui-tabs-nav').outerHeight(true);
     height -= jQuery('div#footer').outerHeight(true);
+    height -= 16 // extra spacing for the footer
 
     if (height < 440) {
         height = 440;

--- a/web/public/js/taginfo.js
+++ b/web/public/js/taginfo.js
@@ -451,12 +451,11 @@ var flexigrid_defaults = {
 };
 
 function calculate_flexigrid_rp(box) {
-    var height = box.innerHeight();
+    var height = box.height();
 
     height -= box.children('h2').outerHeight(true);
-    height -= box.children('.boxpre').outerHeight(true);
     height -= box.children('.pDiv').outerHeight();
-    height -= box.children('.pHiv').outerHeight();
+    height -= box.children('.hDiv').outerHeight();
     height -= 90; // table tools and header, possibly horizontal scrollbar
 
     return Math.floor(height / 26);

--- a/web/views/key.erb
+++ b/web/views/key.erb
@@ -1,6 +1,8 @@
 <div class="pre">
-    <h1></h1>
-    <p><%= @desc %></p>
+    <div id="pre-text">
+        <h1></h1>
+        <p><%= @desc %></p>
+    </div>
     <form id="filter-form">
         <label for="filter"><%= h(t.pages.key.filter.label) %></label>
         <select id="filter" name="filter">

--- a/web/views/key.erb
+++ b/web/views/key.erb
@@ -1,4 +1,4 @@
-<div class="pre">
+<div class="pre ui-helper-clearfix">
     <div id="pre-text">
         <h1></h1>
         <p><%= @desc %></p>

--- a/web/views/key.erb
+++ b/web/views/key.erb
@@ -1,4 +1,6 @@
 <div class="pre">
+    <h1></h1>
+    <p><%= @desc %></p>
     <form id="filter-form">
         <label for="filter"><%= h(t.pages.key.filter.label) %></label>
         <select id="filter" name="filter">
@@ -30,8 +32,6 @@
         <% end %>
         <%= turbo_link(@count_all_values, @filter_type, @key) %>
     </div>
-    <h1></h1>
-    <p><%= @desc %></p>
 </div>
 <div id="tabs">
     <ul class="no-print">

--- a/web/views/layout.erb
+++ b/web/views/layout.erb
@@ -4,6 +4,7 @@
     <title><%= h(title) %></title>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <meta name="content-language" content="<%= r18n.locale.code %>" />
+    <meta name=viewport content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="/css/taginfo.css" />
     <link rel="stylesheet" type="text/css" href="/css/smoothness/jquery-ui-1.8.10.custom-minified.css" />
     <link rel="stylesheet" type="text/css" href="/css/flexigrid/flexigrid-minified.css" />

--- a/web/views/layout.erb
+++ b/web/views/layout.erb
@@ -17,6 +17,15 @@
 </head>
 <body>
     <div id="header">
+        <div id="header_logo">
+            <a href="/"><img width="49" height="49" src="<%= TaginfoConfig.get('instance.icon', '/img/logo/world.png') %>" alt="taginfo"/></a>
+<% if @section %>
+            <a href="/"><img width="136" height="49" src="/img/logo/taginfo_with_bar.png" alt="taginfo"/></a>
+            <a class="section" href="/<%= @section %>"><%= @section_title %></a>
+<% else %>
+            <a href="/"><img width="129" height="49" src="/img/logo/taginfo.png" alt="taginfo"/></a>
+<% end %>
+        </div>
         <div id="header_date" title="<%= h(t.taginfo.data_from_description) %>" tipsy="ne"><%= h(t.taginfo.data_from) %>: <%= @data_until %> UTC</div>
         <div id="header_forms" class="no-print">
             <form id="set_language" action="/switch_locale">
@@ -29,15 +38,6 @@
             </form>
 <% unless @nosearch %>
             <form id="search_form" action="/search"><input type="text" id="search" name="q" value="<%= h(params[:q]) %>"/></form>
-<% end %>
-        </div>
-        <div id="header_logo">
-            <a href="/"><img width="49" height="49" src="<%= TaginfoConfig.get('instance.icon', '/img/logo/world.png') %>" alt="taginfo"/></a>
-<% if @section %>
-            <a href="/"><img width="136" height="49" src="/img/logo/taginfo_with_bar.png" alt="taginfo"/></a>
-            <a class="section" href="/<%= @section %>"><%= @section_title %></a>
-<% else %>
-            <a href="/"><img width="129" height="49" src="/img/logo/taginfo.png" alt="taginfo"/></a>
 <% end %>
         </div>
     </div>

--- a/web/views/layout.erb
+++ b/web/views/layout.erb
@@ -17,7 +17,7 @@
 <%= javascript_tags %>
 </head>
 <body>
-    <div id="header">
+    <div id="header" class="ui-helper-clearfix">
         <div id="header_logo">
             <a href="/"><img width="49" height="49" src="<%= TaginfoConfig.get('instance.icon', '/img/logo/world.png') %>" alt="taginfo"/></a>
 <% if @section %>
@@ -44,7 +44,7 @@
     <div id="main">
 <%= yield %>
     </div>
-    <div id="footer" class="no-print">
+    <div id="footer" class="ui-helper-clearfix" class="no-print">
         <div id="footer_left"><a class="extlink" href="//www.openstreetmap.org/"><b>OpenStreetMap</b></a> &middot;
             <a href="//www.openstreetmap.org/copyright">Data &copy; OSM contributors (ODbL)</a></div>
         <div id="footer_right">

--- a/web/views/layout.erb
+++ b/web/views/layout.erb
@@ -45,7 +45,7 @@
     <div id="main">
 <%= yield %>
     </div>
-    <div id="footer" class="ui-helper-clearfix" class="no-print">
+    <div id="footer" class="ui-helper-clearfix no-print">
         <div id="footer_left"><a class="extlink" href="//www.openstreetmap.org/"><b>OpenStreetMap</b></a> &middot;
             <a href="//www.openstreetmap.org/copyright">Data &copy; OSM contributors (ODbL)</a></div>
         <div id="footer_right">

--- a/web/views/layout.erb
+++ b/web/views/layout.erb
@@ -26,7 +26,6 @@
             <a href="/"><img width="129" height="49" src="/img/logo/taginfo.png" alt="taginfo"/></a>
 <% end %>
         </div>
-        <div id="header_date" title="<%= h(t.taginfo.data_from_description) %>" tipsy="ne"><%= h(t.taginfo.data_from) %>: <%= @data_until %> UTC</div>
         <div id="header_forms" class="no-print">
             <form id="set_language" action="/switch_locale">
                 <input type="hidden" id="url" name="url" value="<%= request.path %>"/>
@@ -60,6 +59,7 @@
             <a id="help_link" href="#help"><%= h(t.misc.help) %></a> &middot;
             <a class="extlink" href="//wiki.openstreetmap.org/wiki/Taginfo"><%= h(t.taginfo.wiki) %></a>
         </div>
+        <div id="footer_date" title="<%= h(t.taginfo.data_from_description) %>" tipsy="ne"><%= h(t.taginfo.data_from) %>: <%= @data_until %> UTC</div>
     </div>
     <div id="javascriptmsg">This website only works with Javascript! Please enable Javascript in your browser.</div>
     <div id="help"><div id="help_tabs">

--- a/web/views/layout.erb
+++ b/web/views/layout.erb
@@ -27,6 +27,7 @@
             <a href="/"><img width="129" height="49" src="/img/logo/taginfo.png" alt="taginfo"/></a>
 <% end %>
         </div>
+        <div id="header_date" title="<%= h(t.taginfo.data_from_description) %>" tipsy="ne"><%= h(t.taginfo.data_from) %>: <%= @data_until %> UTC</div>
         <div id="header_forms" class="no-print">
             <form id="set_language" action="/switch_locale">
                 <input type="hidden" id="url" name="url" value="<%= request.path %>"/>
@@ -60,7 +61,6 @@
             <a id="help_link" href="#help"><%= h(t.misc.help) %></a> &middot;
             <a class="extlink" href="//wiki.openstreetmap.org/wiki/Taginfo"><%= h(t.taginfo.wiki) %></a>
         </div>
-        <div id="footer_date" title="<%= h(t.taginfo.data_from_description) %>" tipsy="ne"><%= h(t.taginfo.data_from) %>: <%= @data_until %> UTC</div>
     </div>
     <div id="javascriptmsg">This website only works with Javascript! Please enable Javascript in your browser.</div>
     <div id="help"><div id="help_tabs">

--- a/web/views/relation.erb
+++ b/web/views/relation.erb
@@ -1,6 +1,8 @@
 <div class="pre">
-    <h1></h1>
-    <p><%= @desc %></p>
+    <div id="pre-text">
+        <h1></h1>
+        <p><%= @desc %></p>
+    </div>
     <div id="tools" class="no-print">
         <% if @count_all_values <= TaginfoConfig.get('xapi.max_results', 1000) %>
             <%= xapi_link('relation', 'type', @rtype) %> <%= josm_link('relation', 'type', @rtype) %>

--- a/web/views/relation.erb
+++ b/web/views/relation.erb
@@ -1,4 +1,4 @@
-<div class="pre">
+<div class="pre ui-helper-clearfix">
     <div id="pre-text">
         <h1></h1>
         <p><%= @desc %></p>

--- a/web/views/relation.erb
+++ b/web/views/relation.erb
@@ -1,4 +1,6 @@
 <div class="pre">
+    <h1></h1>
+    <p><%= @desc %></p>
     <div id="tools" class="no-print">
         <% if @count_all_values <= TaginfoConfig.get('xapi.max_results', 1000) %>
             <%= xapi_link('relation', 'type', @rtype) %> <%= josm_link('relation', 'type', @rtype) %>
@@ -8,8 +10,6 @@
         <% end %>
         <%= turbo_link(@count_all_values, 'relations', 'type', @rtype) %>
     </div>
-    <h1></h1>
-    <p><%= @desc %></p>
 </div>
 <div id="tabs">
     <ul>

--- a/web/views/tag.erb
+++ b/web/views/tag.erb
@@ -1,6 +1,8 @@
 <div class="pre">
-    <h1></h1>
-    <p><%= @desc %></p>
+    <div id="pre-text">
+        <h1></h1>
+        <p><%= @desc %></p>
+    </div>
     <form id="filter-form">
         <label for="filter"><%= h(t.pages.key.filter.label) %></label>
         <select id="filter" name="filter">

--- a/web/views/tag.erb
+++ b/web/views/tag.erb
@@ -1,4 +1,6 @@
 <div class="pre">
+    <h1></h1>
+    <p><%= @desc %></p>
     <form id="filter-form">
         <label for="filter"><%= h(t.pages.key.filter.label) %></label>
         <select id="filter" name="filter">
@@ -30,8 +32,6 @@
         <% end %>
         <%= turbo_link(@count_all, @filter_type, @key, @value) %>
     </div>
-    <h1></h1>
-    <p><%= @desc %></p>
 </div>
 <div id="tabs">
     <ul>

--- a/web/views/tag.erb
+++ b/web/views/tag.erb
@@ -1,4 +1,4 @@
-<div class="pre">
+<div class="pre ui-helper-clearfix">
     <div id="pre-text">
         <h1></h1>
         <p><%= @desc %></p>


### PR DESCRIPTION
These css changes help prevent elements from overlapping, and make the pages display larger on mobile devices.

I have tried to maintain the current layout, the only change I intended to make is to move the date which the data was updated to the footer (and I don't mind reverting this).

I have also made some changes to the JavaScript, a few small bug fixes, and a minimum height for the box to make it usable regardless of the screen size.
