### PR TITLE
Allow robots to crawl downloads (except full db)

### DIFF
--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -2,7 +2,7 @@ User-agent: *
 Disallow: /api
 Disallow: /compare
 Disallow: /css
-Disallow: /download
+Disallow: /download/taginfo-db.db.bz2
 Disallow: /embed
 Disallow: /img
 Disallow: /js


### PR DESCRIPTION
This allows robots (such as the [internet archive](https://web.archive.org/web/20151015170614/https://taginfo.openstreetmap.org/download)) to crawl and cache taginfo db downloads, except for the excessively large full `taginfo-db`.