### PR TITLE
Fix regex for non-default locale

### DIFF
--- a/tagstats/Makefile
+++ b/tagstats/Makefile
@@ -27,7 +27,7 @@ BYID := $(shell ../bin/taginfo-config.rb tagstats.geodistribution)
 #BYID := SparseMemArray
 #BYID := DenseMemArray
 #BYID := DenseMmapArray
-BYID_LC   := $(shell echo $(BYID) | sed -e 's/\([A-Z]\)/_\1/g' | cut -c2- | tr 'A-Z' 'a-z')
+BYID_LC   := $(shell echo $(BYID) | LC_COLLATE=C sed -e 's/\([A-Z]\)/_\1/g' | cut -c2- | tr 'A-Z' 'a-z')
 BYID_INCL := "<osmium/index/map/$(BYID_LC).hpp>"
 
 CXXFLAGS_FEATURES += -DTAGSTATS_GEODISTRIBUTION_INT=$(GEODISTRIBUTION_TYPE)


### PR DESCRIPTION
Regex [a-z] is locale dependent. Force LC_COLLATE=C to work around.

More information: http://unix.stackexchange.com/questions/15980/