### PR TITLE
Fix quote screening for level0 link

### DIFF
--- a/web/public/js/taginfo.js
+++ b/web/public/js/taginfo.js
@@ -557,7 +557,7 @@ function table_right() {
 /* ============================ */
 
 function quote_double(text) {
-    return text.replace(/["\\]/, '\\$&', 'gm')
+    return text.replace(/["\\]/gm, '\\$&');
 }
 
 function level0_editor(overpass_url_prefix, level0_url_prefix, filter, key, value) {


### PR DESCRIPTION
See https://github.com/Zverik/Level0/issues/29
`text.replace` call is incorrect, I've put regexp modifiers back into the regexp.